### PR TITLE
Update README.md to include information about Firefox 31+

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Stylized logs are supported in the following browsers:
 
 - Chrome 26+
-- Firefox with [Firebug 1.11 beta 2](http://blog.getfirebug.com/2012/11/16/firebug-1-11-beta-2/) or later
+- Firefox 31+ or with [Firebug 1.11 beta 2](http://blog.getfirebug.com/2012/11/16/firebug-1-11-beta-2/) or later
 - Opera with Blink (15+)
 - Safari Nightly (537.38+)
 


### PR DESCRIPTION
Firefox 31+ added support to stylized logs. 

In this commit I just update the README.md file to include that info.
