### PR TITLE
fixing AMD export

### DIFF
--- a/log.js
+++ b/log.js
@@ -150,7 +150,9 @@
   exportedLog.l = _log;
 
   if (typeof define === 'function' && define.amd) {
-    define(exportedLog);
+    define(function defineLog() {
+      return exportedLog;
+    });
   } else if (typeof exports !== 'undefined') {
     module.exports = exportedLog;
   } else {


### PR DESCRIPTION
the function passed into `define()` is executed by RequireJS, so you need to wrap the function you return in an initializer…
