### PR TITLE
Offer a way to include the library into an arbitrary namespace

### DIFF
--- a/log.js
+++ b/log.js
@@ -1,5 +1,19 @@
 (function() {
-  var exportedLog, ffSupport, formats, getOrderedMatches, hasMatches, isFF, isIE, isOpera, isSafari, log, makeArray, operaSupport, safariSupport, stringToArgs, _log;
+  var exportedLog,
+    ffSupport,
+    formats,
+    getOrderedMatches,
+    hasMatches,
+    isFF,
+    isIE,
+    isOpera,
+    isSafari,
+    log,
+    makeArray,
+    operaSupport,
+    safariSupport,
+    stringToArgs,
+    _log;
 
   if (!(window.console && window.console.log)) {
     return;
@@ -10,7 +24,7 @@
     args = [];
     makeArray(arguments).forEach(function(arg) {
       if (typeof arg === 'string') {
-        return args = args.concat(stringToArgs(arg));
+        return (args = args.concat(stringToArgs(arg)));
       } else {
         return args.push(arg);
       }
@@ -19,7 +33,11 @@
   };
 
   _log = function() {
-    return Function.prototype.apply.call(console.log, console, makeArray(arguments));
+    return Function.prototype.apply.call(
+      console.log,
+      console,
+      makeArray(arguments)
+    );
   };
 
   makeArray = function(arrayLikeThing) {
@@ -30,31 +48,37 @@
     {
       regex: /\*([^\*]+)\*/,
       replacer: function(m, p1) {
-        return "%c" + p1 + "%c";
+        return '%c' + p1 + '%c';
       },
       styles: function() {
         return ['font-style: italic', ''];
       }
-    }, {
+    },
+    {
       regex: /\_([^\_]+)\_/,
       replacer: function(m, p1) {
-        return "%c" + p1 + "%c";
+        return '%c' + p1 + '%c';
       },
       styles: function() {
         return ['font-weight: bold', ''];
       }
-    }, {
+    },
+    {
       regex: /\`([^\`]+)\`/,
       replacer: function(m, p1) {
-        return "%c" + p1 + "%c";
+        return '%c' + p1 + '%c';
       },
       styles: function() {
-        return ['background: rgb(255, 255, 219); padding: 1px 5px; border: 1px solid rgba(0, 0, 0, 0.1)', ''];
+        return [
+          'background: rgb(255, 255, 219); padding: 1px 5px; border: 1px solid rgba(0, 0, 0, 0.1)',
+          ''
+        ];
       }
-    }, {
-      regex: /\[c\=(?:\"|\')?((?:(?!(?:\"|\')\]).)*)(?:\"|\')?\]((?:(?!\[c\]).)*)\[c\]/,
+    },
+    {
+      regex: /<style\=(?:\"|\')?((?:(?!(?:\"|\')>).)*)(?:\"|\')?>((?:(?!<\/style>).)*)<\/style>/,
       replacer: function(m, p1, p2) {
-        return "%c" + p2 + "%c";
+        return '%c' + p2 + '%c';
       },
       styles: function(match) {
         return [match[1], ''];
@@ -67,7 +91,7 @@
     _hasMatches = false;
     formats.forEach(function(format) {
       if (format.regex.test(str)) {
-        return _hasMatches = true;
+        return (_hasMatches = true);
       }
     });
     return _hasMatches;
@@ -104,7 +128,10 @@
   };
 
   isSafari = function() {
-    return /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
+    return (
+      /Safari/.test(navigator.userAgent) &&
+      /Apple Computer/.test(navigator.vendor)
+    );
   };
 
   isOpera = function() {
@@ -125,7 +152,7 @@
     if (!m) {
       return false;
     }
-    return 537.38 <= parseInt(m[1], 10) + (parseInt(m[2], 10) / 100);
+    return 537.38 <= parseInt(m[1], 10) + parseInt(m[2], 10) / 100;
   };
 
   operaSupport = function() {
@@ -141,7 +168,12 @@
     return window.console.firebug || window.console.exception;
   };
 
-  if (isIE() || (isFF() && !ffSupport()) || (isOpera() && !operaSupport()) || (isSafari() && !safariSupport())) {
+  if (
+    isIE() ||
+    (isFF() && !ffSupport()) ||
+    (isOpera() && !operaSupport()) ||
+    (isSafari() && !safariSupport())
+  ) {
     exportedLog = _log;
   } else {
     exportedLog = log;
@@ -158,5 +190,4 @@
   } else {
     window.log = exportedLog;
   }
-
-}).call(this);
+}.call(this));


### PR DESCRIPTION
Changes suggested:

- pass in the window object by parameter into the IIFE directly rather than use `call`. This patterns mimics some of the major libraries in javascript and is functionally equivalent.

- add `restorePreviousLogRef` function that restores the `window.log` reference to whatever it was prior to loading the log library. This feature is exported via the export `if` conditional from line 195 of the code base. Example use case below:

```
window.log = 'original reference to another library named AnotherLog';

// log library is loaded into the window object, which over-rides the window.log reference

// the new feature is called which returns the original value of window.log, and stores the new library in another variable on the window object.
var adamsLogLibrary = log.restorePreviousLogRef();
```





- code was formatted with prettier.